### PR TITLE
fix how vehicle coordinates are updated

### DIFF
--- a/app/Models/Vehicle.php
+++ b/app/Models/Vehicle.php
@@ -12,8 +12,13 @@ class Vehicle extends Model
 
     public $incrementing = false;
 
-    protected $keyType = 'integer';
-    
+    /**
+     * @var string
+     * 
+     * Distance between rides in meters
+     */
+    const DISTANCE_BETWEEN_RIDES = 60;
+
     /**
      * Distance between the vehicle position and given position in meters
      */

--- a/app/Observers/VehicleObserver.php
+++ b/app/Observers/VehicleObserver.php
@@ -7,22 +7,34 @@ use App\Models\Vehicle;
 
 class VehicleObserver
 {
-    public function updated(Vehicle $vehicle): void
+    public function updating(Vehicle $vehicle): void
     {
-        $this->checkForNewRide($vehicle);
-    }
+        if (!$this->positionChanged($vehicle)) {
+            return;
+        }
 
-    protected function checkForNewRide(Vehicle $vehicle): void
-    { 
         $distanceFromPreviousPosition = $vehicle->distanceFrom(
-            $vehicle->getOriginal('lat'),
-            $vehicle->getOriginal('lng')
+            $originalLat = $vehicle->getOriginal('lat'),
+            $originalLng = $vehicle->getOriginal('lng')
         );
 
-        if ($distanceFromPreviousPosition < 60) {
+        if ($distanceFromPreviousPosition < Vehicle::DISTANCE_BETWEEN_RIDES) {
+            $vehicle->lat = $originalLat;
+            $vehicle->lng = $originalLng;
+        }
+    }
+
+    public function updated(Vehicle $vehicle): void
+    {
+        if (!$this->positionChanged($vehicle)) {
             return;
         }
 
         (new Ride())->vehicle()->associate($vehicle)->save();
+    }
+
+    protected function positionChanged(Vehicle $vehicle): bool
+    {
+        return $vehicle->isDirty('lat') || $vehicle->isDirty('lng');
     }
 }

--- a/tests/Feature/Models/VehicleTest.php
+++ b/tests/Feature/Models/VehicleTest.php
@@ -11,7 +11,7 @@ class VehicleTest extends TestCase
 {
     use RefreshDatabase;
     
-    public function testItCreatesANewRideIfDistanceChangedBy60metersOrMore()
+    public function testItUpdatesCoordinatesAndCreatesARideIfDisnatceBetweenOldAndNewCoordinatesIsMoreOrEqualThan60Meters()
     {
         $vehicleA = Vehicle::factory([
             'lat' => 41.446884,
@@ -23,17 +23,24 @@ class VehicleTest extends TestCase
             'lng' => 2.245076,
         ])->create();
 
+
         $vehicleA->update([
             'lat' => 41.381821,
             'lng' => 2.172203,
         ]);
 
         $vehicleB->update([
-            // only last decimal changed
+            // only last decimal changed, this coordinates won't be updated
             'lat' => 41.446885,
             'lng' => 2.245077,
         ]);
-        
+
+        $this->assertEquals(41.381821, $vehicleA->lat);
+        $this->assertEquals(2.172203, $vehicleA->lng);
+
+        $this->assertEquals(41.446884, $vehicleB->lat);
+        $this->assertEquals(2.245076, $vehicleB->lng);
+
         $rides = Ride::all();
 
         $this->assertCount(1, $rides);


### PR DESCRIPTION
Rather than updating vehicle coordinates every single time, update them only when the distance between old and new coordinates is 60m or more, and in that case also create the ride